### PR TITLE
Fix: invoice details on dialog were not shown correctly

### DIFF
--- a/app/home/invoices/page.tsx
+++ b/app/home/invoices/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useCallback, useEffect, useState } from "react";
 
-// import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -15,16 +14,6 @@ import { Progress } from "@/components/ui/progress";
 
 import { Dialog, DialogContent, DialogHeader } from "@/components/ui/dialog";
 
-// import {
-//   Drawer,
-//   DrawerClose,
-//   DrawerContent,
-//   DrawerDescription,
-//   DrawerFooter,
-//   DrawerHeader,
-//   DrawerTitle,
-// } from "@/components/ui/drawer";
-
 import { Invoice, invoiceService } from "@/lib/supabase/services/invoice";
 import InvoiceView from "@/components/molecules/InvoiceView2";
 import { InvoicesTable } from "@/components/molecules/InvoicesTable";
@@ -35,6 +24,7 @@ import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 // import { PlusCircleIcon } from "lucide-react";
 import CreateInvoiceButton from "@/components/molecules/CreateInvoiceButton";
 import { useInvoicesStore } from "@/store/invoicesStore";
+import { useCompanyStore } from "@/store/companyStore";
 
 export default function Invoices() {
   // const [allInvoices, setAllInvoices] = useState<Invoice[]>([]);
@@ -55,24 +45,22 @@ export default function Invoices() {
     "paid",
     "cancelled",
   ]);
-  const { company } = useAccount();
-  const [isContentReady, setIsContentReady] = useState(false);
+  const { company } = useCompanyStore();
+  const [isInvoiceContentReady, setIsInvoiceContentReady] = useState(false);
 
   useEffect(() => {
     if (isOpen && company) {
-      setIsContentReady(true);
+      setIsInvoiceContentReady(true);
     } else {
-      setIsContentReady(false);
+      setIsInvoiceContentReady(false);
     }
   }, [isOpen, company]);
-  console.log("Company:", company);
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
   // const isDesktop = useMediaQuery("(min-width: 768px)");
   useEffect(() => {
     const initializeData = async () => {
       try {
-        // await fetchInvoices();
         setFilteredInvoices(allInvoices);
         await fetchRevenue();
       } catch (error) {
@@ -250,13 +238,15 @@ export default function Invoices() {
       1,
     );
 
-    const weeklyRevenue = filteredInvoices
-      .filter((invoice) => new Date(invoice.date) >= oneWeekAgo)
-      .reduce((sum, invoice) => sum + invoice.total, 0);
-
-    const monthlyRevenue = filteredInvoices
-      .filter((invoice) => new Date(invoice.date) >= firstDayOfMonth)
-      .reduce((sum, invoice) => sum + invoice.total, 0);
+    // console.log("The filteredInvoices are: ", filteredInvoices);
+    // const weeklyRevenue = filteredInvoices
+    //   .filter((invoice) => new Date(invoice.date) >= oneWeekAgo)
+    //   .reduce((sum, invoice) => sum + invoice.total, 0);
+    // console.log("the weekly revenue is: ", weeklyRevenue);
+    //
+    // const monthlyRevenue = filteredInvoices
+    //   .filter((invoice) => new Date(invoice.date) >= firstDayOfMonth)
+    //   .reduce((sum, invoice) => sum + invoice.total, 0);
 
     const weeklyPercentage =
       monthlyRevenue !== 0 ? (weeklyRevenue / monthlyRevenue) * 100 : 0;
@@ -339,7 +329,7 @@ export default function Invoices() {
               <DialogTitle></DialogTitle>
             </VisuallyHidden.Root>
           </DialogHeader>
-          {isContentReady && (
+          {isInvoiceContentReady && (
             <div className="h-full overflow-y-auto px-4 py-6">
               {(selectedInvoice || isCreatingInvoice) && company && (
                 <InvoiceView
@@ -350,7 +340,7 @@ export default function Invoices() {
               )}
             </div>
           )}
-          {!isContentReady && (
+          {!isInvoiceContentReady && (
             <div className="flex items-center justify-center h-full">
               Loading...
             </div>

--- a/components/molecules/InvoiceView2.tsx
+++ b/components/molecules/InvoiceView2.tsx
@@ -186,6 +186,7 @@ const InvoiceView2: React.FC<InvoiceViewProps> = ({
     handleSubmit,
     watch,
     setValue,
+    getValues,
     formState: { isDirty, isValid, errors },
     setError,
   } = useForm<Invoice>({
@@ -217,6 +218,7 @@ const InvoiceView2: React.FC<InvoiceViewProps> = ({
     control,
     name: "invoice_items",
   });
+  const noProductsAdded: boolean = getValues("invoice_items").length === 0;
 
   const watchInvoiceItems = watch("invoice_items");
 
@@ -300,6 +302,8 @@ const InvoiceView2: React.FC<InvoiceViewProps> = ({
     if (!regex.test(value)) {
       return "El número de factura debe tener el formato 000-000-00-00000000";
     }
+    if (!invoiceService.isInvoiceNumberValid(value, company!.range_invoice2))
+      return "El número de factura está fuera del rango de facturación actual";
     return true;
   };
 
@@ -325,6 +329,9 @@ const InvoiceView2: React.FC<InvoiceViewProps> = ({
             </Select>
           )}
         />
+        {errors.customer_id && (
+          <p className="text-red-500 text-sm">{errors.customer_id.message}</p>
+        )}
         <Controller
           name="date"
           control={control}
@@ -377,41 +384,43 @@ const InvoiceView2: React.FC<InvoiceViewProps> = ({
             </TableHeader>
             <TableBody>
               {fields.map((item, index) => (
-                <TableRow key={item.id}>
-                  <TableCell>
-                    <ProductSelect
-                      index={index}
-                      products={products}
-                      control={control}
-                      setValue={setValue}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <DescriptionInput index={index} control={control} />
-                  </TableCell>
-                  <TableCell>
-                    <QuantityInput index={index} control={control} />
-                  </TableCell>
-                  <TableCell>
-                    <UnitCostInput index={index} control={control} />
-                  </TableCell>
-                  <TableCell>
-                    <DiscountInput index={index} control={control} />
-                  </TableCell>
-                  <TableCell>
-                    {`Lps. ${calculateItemTotal(index, watchInvoiceItems)}`}
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      type="button"
-                      variant="destructive"
-                      size="icon"
-                      onClick={() => remove(index)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </TableCell>
-                </TableRow>
+                <>
+                  <TableRow key={item.id}>
+                    <TableCell>
+                      <ProductSelect
+                        index={index}
+                        products={products}
+                        control={control}
+                        setValue={setValue}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <DescriptionInput index={index} control={control} />
+                    </TableCell>
+                    <TableCell>
+                      <QuantityInput index={index} control={control} />
+                    </TableCell>
+                    <TableCell>
+                      <UnitCostInput index={index} control={control} />
+                    </TableCell>
+                    <TableCell>
+                      <DiscountInput index={index} control={control} />
+                    </TableCell>
+                    <TableCell>
+                      {`Lps. ${calculateItemTotal(index, watchInvoiceItems)}`}
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        size="icon"
+                        onClick={() => remove(index)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                </>
               ))}
             </TableBody>
           </Table>
@@ -464,7 +473,12 @@ const InvoiceView2: React.FC<InvoiceViewProps> = ({
         </Button>
       </div>
       {/* Inhabilita el botón si el formulario no se ha tocado y todas las entradas aún son inválidas */}
-      <Button type="submit" className="mt-4" disabled={!isDirty || !isValid}>
+      <Button
+        type="submit"
+        className="mt-4"
+        // disabled={noProductsAdded && (!isDirty || !isValid)}
+        disabled={noProductsAdded}
+      >
         Generar Factura
       </Button>
     </form>

--- a/components/molecules/InvoicesTable.tsx
+++ b/components/molecules/InvoicesTable.tsx
@@ -162,7 +162,6 @@ export const InvoicesTable: React.FC<InvoicesTableProps> = ({
   onUpdateStatus,
   selectedStatuses,
 }) => {
-  console.log("invoices", invoices);
   const [searchTerm, setSearchTerm] = useState("");
   const [startDate, setStartDate] = useState<Date | undefined>();
   const [endDate, setEndDate] = useState<Date | undefined>();

--- a/lib/supabase/services/invoice.ts
+++ b/lib/supabase/services/invoice.ts
@@ -47,7 +47,24 @@ export interface InvoiceItem {
 class InvoiceService extends BaseService {
   private tableName: Table = "invoices";
 
-  // Helper method to ensure company ID is available
+  /**
+   * Ensures that a valid company ID is available for generating an invoice.
+   *
+   * @private
+   * @async
+   * @returns {Promise<string | null>} - Returns the company ID as a string if available; otherwise, returns null.
+   *   - Logs an error message if no company ID is found.
+   *
+   * @example
+   * async function generateInvoice() {
+   *   const companyId = await ensureCompanyIdForInvoice();
+   *   if (companyId) {
+   *     // Proceed with invoice generation
+   *   } else {
+   *     // Handle missing company ID case
+   *   }
+   * }
+   */
   private async ensureCompanyIdForInvoice(): Promise<string | null> {
     const companyId = await this.ensureCompanyId();
     if (!companyId) {
@@ -55,6 +72,42 @@ class InvoiceService extends BaseService {
     }
     return companyId;
   }
+
+  /**
+   * Computes the subtotal, tax, and total for a given list of invoice items.
+   *
+   * @param {InvoiceItem[]} invoiceItems - Array of items on the invoice. Each item should have:
+   *   - {number} quantity - Quantity of the item.
+   *   - {number} unit_cost - Unit cost of the item.
+   * @returns {{ subtotal: number, tax: number, total: number }} - Object containing:
+   *   - subtotal: Sum of all items (quantity * unit_cost for each item).
+   *   - tax: Total tax calculated at 15% of the subtotal.
+   *   - total: Final total including tax.
+   *
+   * @example
+   * const items = [
+   *   { quantity: 2, unit_cost: 50 },
+   *   { quantity: 1, unit_cost: 100 }
+   * ];
+   * computeInvoiceData(items);
+   * // Returns: { subtotal: 200, tax: 30, total: 230 }
+   *
+   * @example
+   * const items = [
+   *   { quantity: 3, unit_cost: 40 },
+   *   { quantity: 4, unit_cost: 60 }
+   * ];
+   * computeInvoiceData(items);
+   * // Returns: { subtotal: 360, tax: 54, total: 414 }
+   *
+   * @example
+   * const items = [
+   *   { quantity: 5, unit_cost: 10 },
+   *   { quantity: 2, unit_cost: 15 }
+   * ];
+   * computeInvoiceData(items);
+   * // Returns: { subtotal: 80, tax: 12, total: 92 }
+   */
 
   computeInvoiceData(invoiceItems: InvoiceItem[]): {
     subtotal: number;


### PR DESCRIPTION
It was using a custom hook that entailed computation overload. This patch uses the company data retrieved at first. Moreover, this also adds an alert when you try to set an invoice number out of range