### PR TITLE
Company data from previous session still present

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -13,17 +13,31 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { useRouter } from "next/navigation";
 import { toast } from "@/components/ui/use-toast";
+import { useIsLoadedStore } from "@/store/isLoadedStore";
+import { useCompanyStore } from "@/store/companyStore";
+import { useCustomersStore } from "@/store/customersStore";
+import { useInvoicesStore } from "@/store/invoicesStore";
+import { useProductsStore } from "@/store/productsStore";
 
 const LoginPage: React.FC = () => {
+  const { resetCompany } = useCompanyStore();
+  const { resetCustomers } = useCustomersStore();
+  const { resetInvoices } = useInvoicesStore();
+  const { resetIsLoaded } = useIsLoadedStore();
+  const { resetProducts } = useProductsStore();
   const [isLogin, setIsLogin] = useState(true);
-  const router = useRouter();
 
   const toggleForm = () => setIsLogin(!isLogin);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    // 1. Make sure to delete all kind of user data!
+    resetProducts();
+    resetIsLoaded();
+    resetInvoices();
+    resetCustomers();
+    resetCompany();
     const formData = new FormData(event.currentTarget);
 
     try {

--- a/lib/supabase/auth.ts
+++ b/lib/supabase/auth.ts
@@ -8,8 +8,6 @@ import { createClient } from "@/lib/supabase/server";
 export async function login(formData: FormData) {
   const supabase = createClient();
 
-  console.log("login", formData);
-
   const data = {
     email: formData.get("email") as string,
     password: formData.get("password") as string,
@@ -17,7 +15,6 @@ export async function login(formData: FormData) {
 
   const { error } = await supabase.auth.signInWithPassword(data);
 
-  console.log("login error", error);
   if (error) {
     return error;
   }
@@ -25,8 +22,6 @@ export async function login(formData: FormData) {
 
 export async function signup(formData: FormData) {
   const supabase = createClient();
-
-  console.log("signup", formData);
 
   // type-casting here for convenience
   // in practice, you should validate your inputs

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import {
   blockedRoutesForGuests,
+  blockedRoutesForUsers,
   routesThatRequireCompanyData,
 } from "./routeRestrictionsLists";
 
@@ -24,6 +25,12 @@ export async function updateSession(request: NextRequest) {
   );
 
   const routeNeedsACompany: boolean = routesThatRequireCompanyData.some(
+    (route) => {
+      return route.test(request.nextUrl.pathname);
+    },
+  );
+
+  const isRouteBlockedForUsers: boolean = blockedRoutesForUsers.some(
     (route) => {
       return route.test(request.nextUrl.pathname);
     },
@@ -88,6 +95,10 @@ export async function updateSession(request: NextRequest) {
       const urlToSettingsPage = new URL("/home/settings", request.url);
       urlToSettingsPage.searchParams.set("showToast", "companySetupRequired");
       return NextResponse.redirect(urlToSettingsPage);
+    }
+    if (isRouteBlockedForUsers) {
+      const urlToInvoicesPage = new URL("/home/invoices", request.url);
+      return NextResponse.redirect(urlToInvoicesPage);
     }
   }
 

--- a/lib/supabase/routeRestrictionsLists.ts
+++ b/lib/supabase/routeRestrictionsLists.ts
@@ -7,3 +7,6 @@ export const routesThatRequireCompanyData: RegExp[] = [
   /^\/home\/products$/,
   /^\/home\/customers$/,
 ];
+export const blockedRoutesForUsers: RegExp[] = [
+  /^\/auth.*/, // Every route that starts with /auth
+];


### PR DESCRIPTION
When you sign up on Factura.hn, you might have data about the company from the previous session, which shouldn't happen.

Two fixes were given for this:
1. Don't allow users with an active session to access /auth routes.
2. Either you log in or sign up, the local storage will be completely erased.